### PR TITLE
Remove line break added incorrectly in the end of copied code

### DIFF
--- a/lib/copy-code-to-clipboard.js
+++ b/lib/copy-code-to-clipboard.js
@@ -20,7 +20,7 @@ function createCodeBlockWithCopyButton(OrigPre) {
   const CopyCodeToClipboardButton = props => {
     const handleClick = e => {
       (async () => {
-        await _electron.clipboard.writeText(props.text);
+        await _electron.clipboard.writeText(props.text.replace(/\n$/g, ''));
       })();
     };
 

--- a/src/copy-code-to-clipboard.js
+++ b/src/copy-code-to-clipboard.js
@@ -9,7 +9,7 @@ export default function createCodeBlockWithCopyButton(OrigPre) {
   const CopyCodeToClipboardButton = (props) => {
     const handleClick = (e) => {
       (async () => {
-        await clipboard.writeText(props.text);
+        await clipboard.writeText(props.text.replace(/\n$/g, ''));
       })();
     };
     return (


### PR DESCRIPTION
This PR fix the problem that a `Line Break` is being included in the end of the copied code.
Differently of the content of the code block.